### PR TITLE
[Chore/image] #62 이미지 업로드 방식 수정/리팩토링

### DIFF
--- a/back-end/with-the-developer/src/main/java/com/developer/admin/command/controller/AdminCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/admin/command/controller/AdminCommandController.java
@@ -2,7 +2,7 @@ package com.developer.admin.command.controller;
 
 import com.developer.admin.command.dto.AdminRecruitApplyUpdateDTO;
 import com.developer.admin.command.service.AdminCommandService;
-import com.developer.common.SuccessCode;
+import com.developer.common.success.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;

--- a/back-end/with-the-developer/src/main/java/com/developer/common/success/SuccessCode.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/common/success/SuccessCode.java
@@ -1,4 +1,4 @@
-package com.developer.common;
+package com.developer.common.success;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;

--- a/back-end/with-the-developer/src/main/java/com/developer/comu/command/controller/ComuPostController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/comu/command/controller/ComuPostController.java
@@ -29,6 +29,7 @@ public class ComuPostController {
 
         String userId = SecurityUtil.getCurrentUserId();
 
+        // 게시글 등록
         Long comuPostCode = postAndImageService.comuPostRegist(comuPostCreateDTO, userId, images);
 
         URI location = URI.create("/comu-post/" + comuPostCode);
@@ -46,6 +47,7 @@ public class ComuPostController {
 
         String userId = SecurityUtil.getCurrentUserId();
 
+        // 게시글 수정
         postAndImageService.comuPostUpdate(comuPostUpdateDTO, userId, images);
 
         return ResponseEntity.noContent().build();
@@ -57,6 +59,7 @@ public class ComuPostController {
 
         String userId = SecurityUtil.getCurrentUserId();
 
+        // 게시글 삭제
         postAndImageService.comuPostDelete(comuPostCode, userId);
 
         return ResponseEntity.noContent().build();

--- a/back-end/with-the-developer/src/main/java/com/developer/comu/command/controller/ComuPostController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/comu/command/controller/ComuPostController.java
@@ -2,11 +2,8 @@ package com.developer.comu.command.controller;
 
 import com.developer.comu.command.dto.ComuPostCreateDTO;
 import com.developer.comu.command.dto.ComuPostUpdateDTO;
-import com.developer.comu.command.service.ComuPostService;
-import com.developer.user.command.dto.TokenSaveDTO;
+import com.developer.comu.module.PostAndImageService;
 import com.developer.user.security.SecurityUtil;
-import com.developer.image.command.service.ImageService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -14,30 +11,25 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.net.URI;
+import java.text.ParseException;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/comu-post")
 public class ComuPostController {
 
-    private final ComuPostService comuPostService;
-    private final ImageService imageService;
+    private final PostAndImageService postAndImageService;
 
     // 커뮤니티 게시글 등록
     @PostMapping("/regist")
     public ResponseEntity<Void> createComuPost(
             @RequestPart ComuPostCreateDTO comuPostCreateDTO,
-            @RequestPart MultipartFile[] images,
-            HttpServletRequest httpServletRequest) throws IOException {
+            @RequestPart MultipartFile[] images
+    ) throws IOException, ParseException {
 
         String userId = SecurityUtil.getCurrentUserId();
 
-        Long comuPostCode = comuPostService.createComuPost(comuPostCreateDTO, userId);
-
-        // 이미지가 있다면 이미지 서비스 호출
-        if(images != null && images.length > 0) {
-            imageService.upload(images, "comuPost", comuPostCode);
-        }
+        Long comuPostCode = postAndImageService.comuPostRegist(comuPostCreateDTO, userId, images);
 
         URI location = URI.create("/comu-post/" + comuPostCode);
 
@@ -49,26 +41,23 @@ public class ComuPostController {
     @PutMapping("/update")
     public ResponseEntity<Void> updateComuPost(
             @RequestPart ComuPostUpdateDTO comuPostUpdateDTO,
-            @RequestPart MultipartFile[] images,
-            HttpServletRequest httpServletRequest) throws IOException {
+            @RequestPart MultipartFile[] images
+            ) throws IOException, ParseException {
 
         String userId = SecurityUtil.getCurrentUserId();
 
-        imageService.updateImage(images,"comuPost", comuPostUpdateDTO.getComuCode());
-
-        comuPostService.updateComuPost(comuPostUpdateDTO, userId);
+        postAndImageService.comuPostUpdate(comuPostUpdateDTO, userId, images);
 
         return ResponseEntity.noContent().build();
     }
 
     // 커뮤니티 게시글 삭제
     @DeleteMapping("/delete/{comuPostCode}")
-    public ResponseEntity<Void> deleteComuPost(@PathVariable Long comuPostCode, HttpServletRequest request) {
+    public ResponseEntity<Void> deleteComuPost(@PathVariable Long comuPostCode) {
+
         String userId = SecurityUtil.getCurrentUserId();
 
-        imageService.deleteImage("comuPost", comuPostCode);
-
-        comuPostService.deleteComuPost(comuPostCode, userId);
+        postAndImageService.comuPostDelete(comuPostCode, userId);
 
         return ResponseEntity.noContent().build();
     }

--- a/back-end/with-the-developer/src/main/java/com/developer/comu/command/controller/ComuPostController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/comu/command/controller/ComuPostController.java
@@ -1,6 +1,6 @@
 package com.developer.comu.command.controller;
 
-import com.developer.common.SuccessCode;
+import com.developer.common.success.SuccessCode;
 import com.developer.comu.command.dto.ComuPostCreateDTO;
 import com.developer.comu.command.dto.ComuPostUpdateDTO;
 import com.developer.common.module.PostAndImageService;

--- a/back-end/with-the-developer/src/main/java/com/developer/comu/module/PostAndImageService.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/comu/module/PostAndImageService.java
@@ -1,15 +1,18 @@
 package com.developer.comu.module;
 
+import com.developer.comu.command.dto.ComuPostCreateDTO;
+import com.developer.comu.command.dto.ComuPostUpdateDTO;
 import com.developer.comu.command.service.ComuPostService;
 import com.developer.image.command.service.ImageService;
-import com.developer.project.comment.command.application.service.ProjCmtCommandService;
+import com.developer.project.post.command.application.dto.ProjPostRequestDTO;
+import com.developer.project.post.command.application.service.ProjPostCommandService;
+import com.developer.recruit.command.dto.RecruitApplyDTO;
 import com.developer.recruit.command.service.RecruitCommandService;
 import com.developer.teampost.command.dto.TeamPostDeleteDTO;
 import com.developer.teampost.command.dto.TeamPostRegistDTO;
 import com.developer.teampost.command.dto.TeamPostUpdateDTO;
 import com.developer.teampost.command.service.TeamPostCommandService;
 
-import com.developer.teampost.query.dto.TeamPostDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -27,16 +30,16 @@ public class PostAndImageService {
     private final ImageService imageService;
     private final TeamPostCommandService teamPostCommandService;
     private final ComuPostService comuPostService;
-    private final ProjCmtCommandService projCmtCommandService;
+    private final ProjPostCommandService projPostCommandService;
     private final RecruitCommandService recruitCommandService;
 
     @Transactional
-    public Long teamPostUpload(TeamPostRegistDTO teamPostDTO, MultipartFile[] images) throws ParseException, IOException {
+    public Long teamPostRegist(TeamPostRegistDTO teamPostDTO, MultipartFile[] images) throws ParseException, IOException {
         // 서비스 메소드 호출
         Long createdCode = teamPostCommandService.registTeamPost(teamPostDTO);
 
         // 이미지도 같이 등록 할 경우 ImageService 호출
-        if(images!=null && images.length>0) {
+        if(images!=null && !images[0].isEmpty()) {
             imageService.upload(images, "teamPost", createdCode);
         }
 
@@ -60,5 +63,82 @@ public class PostAndImageService {
         teamPostCommandService.deleteTeamPost(teamPostDTO);
     }
 
+    @Transactional
+    public Long comuPostRegist(ComuPostCreateDTO comuPostDTO, String userId, MultipartFile[] images) throws ParseException, IOException {
 
+        Long createdCode = comuPostService.createComuPost(comuPostDTO, userId);
+
+        // 이미지도 같이 등록 할 경우 ImageService 호출
+        if(images!=null && !images[0].isEmpty()) {
+            imageService.upload(images, "comuPost", createdCode);
+        }
+
+        return createdCode;
+    }
+
+    @Transactional
+    public void comuPostUpdate(ComuPostUpdateDTO comuPostDTO, String userId, MultipartFile[] images) throws ParseException, IOException {
+
+        imageService.updateImage(images,"comuPost", comuPostDTO.getComuCode());
+
+        comuPostService.updateComuPost(comuPostDTO, userId);
+    }
+
+    @Transactional
+    public void comuPostDelete(Long comuPostCode, String userId){
+
+        imageService.deleteImage("comuPost", comuPostCode);
+
+        comuPostService.deleteComuPost(comuPostCode,userId);
+    }
+
+    @Transactional
+    public Long projPostRegist(ProjPostRequestDTO projPostDTO, Long loginUserCode, MultipartFile[] images) throws IOException {
+
+        Long createdCode = projPostCommandService.createProjPost(loginUserCode, projPostDTO);
+
+        if(images!=null && !images[0].isEmpty()) {
+            imageService.upload(images, "projPost", loginUserCode);
+        }
+
+        return createdCode;
+    }
+
+    @Transactional
+    public void projPostUpdate(Long projPostCode, Long loginUserCode, ProjPostRequestDTO projPostRequestDTO, MultipartFile[] images) throws IOException {
+
+        // 이미지 업데이트 호출
+        imageService.updateImage(images,"projPost",projPostCode);
+
+        projPostCommandService.updateProjPost(projPostCode, loginUserCode, projPostRequestDTO);
+    }
+
+    @Transactional
+    public void projPostDelete(Long loginUserCode, Long projPostCode){
+
+        imageService.deleteImage("projPost", projPostCode);
+
+        projPostCommandService.deleteProjPost(loginUserCode, projPostCode);
+    }
+
+    @Transactional
+    public Long recruitPostRegist(RecruitApplyDTO newApplyRecruitDTO, Long loginUserCode, MultipartFile[] images) throws IOException {
+
+        Long createdCode = recruitCommandService.applyRecruit(newApplyRecruitDTO, loginUserCode);
+
+        if(images!=null && !images[0].isEmpty()) {
+            imageService.upload(images, "recruit", loginUserCode);
+        }
+
+        return createdCode;
+    }
+
+    @Transactional
+    public void recruitPostDelete(Long recruitCode, Long loginUserCode) throws Exception {
+
+        imageService.deleteImage("recruit", recruitCode);
+
+        recruitCommandService.deleteRecruit(recruitCode, loginUserCode);
+
+    }
 }

--- a/back-end/with-the-developer/src/main/java/com/developer/comu/module/PostAndImageService.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/comu/module/PostAndImageService.java
@@ -1,0 +1,64 @@
+package com.developer.comu.module;
+
+import com.developer.comu.command.service.ComuPostService;
+import com.developer.image.command.service.ImageService;
+import com.developer.project.comment.command.application.service.ProjCmtCommandService;
+import com.developer.recruit.command.service.RecruitCommandService;
+import com.developer.teampost.command.dto.TeamPostDeleteDTO;
+import com.developer.teampost.command.dto.TeamPostRegistDTO;
+import com.developer.teampost.command.dto.TeamPostUpdateDTO;
+import com.developer.teampost.command.service.TeamPostCommandService;
+
+import com.developer.teampost.query.dto.TeamPostDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class PostAndImageService {
+
+    private final ImageService imageService;
+    private final TeamPostCommandService teamPostCommandService;
+    private final ComuPostService comuPostService;
+    private final ProjCmtCommandService projCmtCommandService;
+    private final RecruitCommandService recruitCommandService;
+
+    @Transactional
+    public Long teamPostUpload(TeamPostRegistDTO teamPostDTO, MultipartFile[] images) throws ParseException, IOException {
+        // 서비스 메소드 호출
+        Long createdCode = teamPostCommandService.registTeamPost(teamPostDTO);
+
+        // 이미지도 같이 등록 할 경우 ImageService 호출
+        if(images!=null && images.length>0) {
+            imageService.upload(images, "teamPost", createdCode);
+        }
+
+        return createdCode;
+    }
+
+    @Transactional
+    public void teamPostUpdate(TeamPostUpdateDTO teamPostUpdateDTO, MultipartFile[] images) throws ParseException, IOException {
+
+        teamPostCommandService.updateTeamPost(teamPostUpdateDTO);
+
+        imageService.updateImage(images,"teamPost",teamPostUpdateDTO.getTeamPostCode());
+
+    }
+
+    @Transactional
+    public void teamPostDelete(TeamPostDeleteDTO teamPostDTO) throws ParseException {
+
+        imageService.deleteImage("teamPost", teamPostDTO.getTeamPostCode());
+
+        teamPostCommandService.deleteTeamPost(teamPostDTO);
+    }
+
+
+}

--- a/back-end/with-the-developer/src/main/java/com/developer/image/command/service/ImageService.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/image/command/service/ImageService.java
@@ -157,12 +157,15 @@ public class ImageService {
             case "recruit" : oldImages = imageRepository.findByRecruitCode(code); break;
             case "goods" : oldImages = imageRepository.findByGoodsCode(code); break;
         }
+
         for(int i=0; i<oldImages.size(); i++){
             deleteS3File(oldImages.get(i).getFileName());
             imageRepository.delete(oldImages.get(i));
         }
 
-        upload(newImages,dir,code);
+        if(newImages != null && newImages[0] != null){
+            upload(newImages,dir,code);
+        }
 
     }
 

--- a/back-end/with-the-developer/src/main/java/com/developer/image/command/service/ImageService.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/image/command/service/ImageService.java
@@ -163,7 +163,7 @@ public class ImageService {
             imageRepository.delete(oldImages.get(i));
         }
 
-        if(newImages != null && newImages[0] != null){
+        if(newImages != null && !newImages[0].isEmpty()){
             upload(newImages,dir,code);
         }
 

--- a/back-end/with-the-developer/src/main/java/com/developer/project/comment/command/application/controller/ProjCmtCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/project/comment/command/application/controller/ProjCmtCommandController.java
@@ -1,6 +1,6 @@
 package com.developer.project.comment.command.application.controller;
 
-import com.developer.common.SuccessCode;
+import com.developer.common.success.SuccessCode;
 import com.developer.project.comment.command.application.dto.ProjCmtRequestDTO;
 import com.developer.project.comment.command.application.service.ProjCmtCommandService;
 import com.developer.user.security.SecurityUtil;

--- a/back-end/with-the-developer/src/main/java/com/developer/project/post/command/application/controller/ProjPostCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/project/post/command/application/controller/ProjPostCommandController.java
@@ -1,6 +1,6 @@
 package com.developer.project.post.command.application.controller;
 
-import com.developer.common.SuccessCode;
+import com.developer.common.success.SuccessCode;
 import com.developer.common.module.PostAndImageService;
 import com.developer.project.post.command.application.dto.ProjPostRequestDTO;
 import com.developer.project.post.command.application.service.ProjPostCommandService;
@@ -53,7 +53,7 @@ public class ProjPostCommandController {
         Long loginUserCode = SecurityUtil.getCurrentUserCode();
 
         // 게시글 삭제
-        projPostCommandService.deleteProjPost(loginUserCode, projPostCode);
+        postAndImageService.projPostDelete(projPostCode, loginUserCode);
 
         return ResponseEntity.ok(SuccessCode.PROJ_POST_DELETE_OK);
     }

--- a/back-end/with-the-developer/src/main/java/com/developer/project/post/command/application/controller/ProjPostCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/project/post/command/application/controller/ProjPostCommandController.java
@@ -1,15 +1,10 @@
 package com.developer.project.post.command.application.controller;
 
-import com.developer.common.exception.CustomException;
-import com.developer.common.exception.ErrorCode;
 import com.developer.common.SuccessCode;
 import com.developer.comu.module.PostAndImageService;
-import com.developer.user.command.dto.TokenSaveDTO;
-import com.developer.image.command.service.ImageService;
 import com.developer.project.post.command.application.dto.ProjPostRequestDTO;
 import com.developer.project.post.command.application.service.ProjPostCommandService;
 import com.developer.user.security.SecurityUtil;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -24,7 +19,6 @@ import java.net.URI;
 public class ProjPostCommandController {
 
     private final ProjPostCommandService projPostCommandService;
-    private final ImageService imageService;
     private final PostAndImageService postAndImageService;
 
     @PostMapping("/post")
@@ -35,6 +29,7 @@ public class ProjPostCommandController {
 
         Long loginUserCode = SecurityUtil.getCurrentUserCode();
 
+        // 게시글 등록
         Long projPostCode = postAndImageService.projPostRegist(projPostRequestDTO, loginUserCode, images);
 
         return ResponseEntity.created(URI.create("/proj/post/" + projPostCode)).build();
@@ -48,15 +43,17 @@ public class ProjPostCommandController {
     ) throws IOException {
         Long loginUserCode = SecurityUtil.getCurrentUserCode();
 
+        // 게시글 수정
         postAndImageService.projPostUpdate(projPostCode, loginUserCode, projPostRequestDTO, images);
 
         return ResponseEntity.ok(SuccessCode.PROJ_POST_UPDATE_OK);
     }
 
     @DeleteMapping("/post/{projPostCode}")
-    public ResponseEntity<SuccessCode> deleteProjPost(@PathVariable Long projPostCode, HttpServletRequest httpServletRequest) {
+    public ResponseEntity<SuccessCode> deleteProjPost(@PathVariable Long projPostCode) {
         Long loginUserCode = SecurityUtil.getCurrentUserCode();
 
+        // 게시글 삭제
         projPostCommandService.deleteProjPost(loginUserCode, projPostCode);
 
         return ResponseEntity.ok(SuccessCode.PROJ_POST_DELETE_OK);

--- a/back-end/with-the-developer/src/main/java/com/developer/project/post/command/application/controller/ProjPostCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/project/post/command/application/controller/ProjPostCommandController.java
@@ -3,6 +3,7 @@ package com.developer.project.post.command.application.controller;
 import com.developer.common.exception.CustomException;
 import com.developer.common.exception.ErrorCode;
 import com.developer.common.SuccessCode;
+import com.developer.comu.module.PostAndImageService;
 import com.developer.user.command.dto.TokenSaveDTO;
 import com.developer.image.command.service.ImageService;
 import com.developer.project.post.command.application.dto.ProjPostRequestDTO;
@@ -24,21 +25,17 @@ public class ProjPostCommandController {
 
     private final ProjPostCommandService projPostCommandService;
     private final ImageService imageService;
+    private final PostAndImageService postAndImageService;
 
     @PostMapping("/post")
     public ResponseEntity<Void> createProjPost(
             @RequestPart ProjPostRequestDTO projPostRequestDTO,
-            @RequestPart MultipartFile[] images,
-            HttpServletRequest httpServletRequest) throws IOException {
+            @RequestPart MultipartFile[] images
+    ) throws IOException {
 
         Long loginUserCode = SecurityUtil.getCurrentUserCode();
 
-        Long projPostCode = projPostCommandService.createProjPost(loginUserCode, projPostRequestDTO);
-
-        // 이미지가 있다면 이미지 서비스 호출
-        if(images != null && images.length > 0) {
-            imageService.upload(images, "projPost", projPostCode);
-        }
+        Long projPostCode = postAndImageService.projPostRegist(projPostRequestDTO, loginUserCode, images);
 
         return ResponseEntity.created(URI.create("/proj/post/" + projPostCode)).build();
     }
@@ -47,14 +44,11 @@ public class ProjPostCommandController {
     public ResponseEntity<SuccessCode> updateProjPost(
             @PathVariable Long projPostCode,
             @RequestPart ProjPostRequestDTO projPostRequestDTO,
-            @RequestPart MultipartFile[] images,
-            HttpServletRequest httpServletRequest) throws IOException {
+            @RequestPart MultipartFile[] images
+    ) throws IOException {
         Long loginUserCode = SecurityUtil.getCurrentUserCode();
 
-        // 이미지 업데이트 호출
-        imageService.updateImage(images,"projPost",projPostCode);
-
-        projPostCommandService.updateProjPost(projPostCode, loginUserCode, projPostRequestDTO);
+        postAndImageService.projPostUpdate(projPostCode, loginUserCode, projPostRequestDTO, images);
 
         return ResponseEntity.ok(SuccessCode.PROJ_POST_UPDATE_OK);
     }

--- a/back-end/with-the-developer/src/main/java/com/developer/recruit/command/controller/RecruitCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/recruit/command/controller/RecruitCommandController.java
@@ -1,6 +1,6 @@
 package com.developer.recruit.command.controller;
 
-import com.developer.common.SuccessCode;
+import com.developer.common.success.SuccessCode;
 import com.developer.common.module.PostAndImageService;
 import com.developer.recruit.command.service.RecruitCommandService;
 import com.developer.recruit.command.dto.RecruitApplyDTO;

--- a/back-end/with-the-developer/src/main/java/com/developer/recruit/command/controller/RecruitCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/recruit/command/controller/RecruitCommandController.java
@@ -31,6 +31,7 @@ public class RecruitCommandController {
         // 로그인 되어 있는지 체크. 로그인 되어 있지 않으면 에러, 되어 있다면 로그인 되어 있는 회원 userCode 반환
         Long loggedUserCode = SecurityUtil.getCurrentUserCode();
 
+        // 게시글 등록
         Long recruitCode = postAndImageService.recruitPostRegist(newApplyRecruitDTO, loggedUserCode, images);
 
         return ResponseEntity
@@ -55,6 +56,7 @@ public class RecruitCommandController {
 
         Long loggedUserCode = SecurityUtil.getCurrentUserCode();
 
+        // 게시글 삭제
         postAndImageService.recruitPostDelete(recruitCode, loggedUserCode);
 
         return ResponseEntity.ok(SuccessCode.RECRUIT_DELETE_OK);

--- a/back-end/with-the-developer/src/main/java/com/developer/recruit/command/controller/RecruitCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/recruit/command/controller/RecruitCommandController.java
@@ -1,11 +1,10 @@
 package com.developer.recruit.command.controller;
 
 import com.developer.common.SuccessCode;
-import com.developer.image.command.service.ImageService;
+import com.developer.comu.module.PostAndImageService;
 import com.developer.recruit.command.service.RecruitCommandService;
 import com.developer.recruit.command.dto.RecruitApplyDTO;
 import com.developer.user.security.SecurityUtil;
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,23 +20,18 @@ import java.net.URI;
 public class RecruitCommandController {
 
     private final RecruitCommandService recruitService;
-    private final ImageService imageService;
+    private final PostAndImageService postAndImageService;
 
     // 채용공고 등록 신청
     @PostMapping("/apply")
     public ResponseEntity<String> applyRecruit(
             @Valid @RequestPart RecruitApplyDTO newApplyRecruitDTO,
-            @RequestPart MultipartFile[] images,
-            HttpServletRequest request) throws IOException {
+            @RequestPart MultipartFile[] images
+    ) throws IOException {
         // 로그인 되어 있는지 체크. 로그인 되어 있지 않으면 에러, 되어 있다면 로그인 되어 있는 회원 userCode 반환
         Long loggedUserCode = SecurityUtil.getCurrentUserCode();
 
-        Long recruitCode = recruitService.applyRecruit(newApplyRecruitDTO, loggedUserCode);
-
-        // 이미지가 있다면 이미지 서비스 호출
-        if(images != null && images.length > 0) {
-            imageService.upload(images, "recruit", recruitCode);
-        }
+        Long recruitCode = postAndImageService.recruitPostRegist(newApplyRecruitDTO, loggedUserCode, images);
 
         return ResponseEntity
                 .created(URI.create("/recruit/apply/" + recruitCode))
@@ -46,8 +40,10 @@ public class RecruitCommandController {
 
     // 채용공고 수동 마감
     @PutMapping("/complete/{recruitCode}")
-    public ResponseEntity<SuccessCode> completeRecruitManual(@PathVariable Long recruitCode, HttpServletRequest request) {
+    public ResponseEntity<SuccessCode> completeRecruitManual(@PathVariable Long recruitCode) {
+
         Long loggedUserCode = SecurityUtil.getCurrentUserCode();
+
         recruitService.completeRecruitManual(recruitCode, loggedUserCode);
 
         return ResponseEntity.ok(SuccessCode.RECRUIT_COMPLETE_OK);
@@ -55,13 +51,11 @@ public class RecruitCommandController {
 
     // 채용공고 삭제
     @DeleteMapping("/delete/{recruitCode}")
-    public ResponseEntity<SuccessCode> deleteRecruit(@PathVariable Long recruitCode, HttpServletRequest request) throws Exception {
+    public ResponseEntity<SuccessCode> deleteRecruit(@PathVariable Long recruitCode) throws Exception {
+
         Long loggedUserCode = SecurityUtil.getCurrentUserCode();
 
-        // 게시글 삭제 시 이미지도 같이 삭제
-        imageService.deleteImage("recruit", recruitCode);
-
-        recruitService.deleteRecruit(recruitCode, loggedUserCode);
+        postAndImageService.recruitPostDelete(recruitCode, loggedUserCode);
 
         return ResponseEntity.ok(SuccessCode.RECRUIT_DELETE_OK);
     }

--- a/back-end/with-the-developer/src/main/java/com/developer/teampost/command/controller/TeamPostCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/teampost/command/controller/TeamPostCommandController.java
@@ -1,14 +1,11 @@
 package com.developer.teampost.command.controller;
 
 
-import com.developer.common.exception.CustomException;
-import com.developer.common.exception.ErrorCode;
 import com.developer.comu.module.PostAndImageService;
 import com.developer.teampost.command.dto.TeamPostDeleteDTO;
 import com.developer.teampost.command.dto.TeamPostRegistDTO;
 import com.developer.teampost.command.dto.TeamPostUpdateDTO;
 import com.developer.user.security.SecurityUtil;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -38,6 +35,7 @@ public class TeamPostCommandController {
         // 로그인 중인 유저 코드 받아와 DTO에 삽입
         teamPostDTO.setUserCode(SecurityUtil.getCurrentUserCode());
 
+        // 게시글 등록
         Long createdCode = postAndImageService.teamPostRegist(teamPostDTO, images);
 
 
@@ -55,6 +53,7 @@ public class TeamPostCommandController {
         // 로그인 중인 유저 코드 받아와 DTO에 삽입
         teamPostDTO.setUserCode(SecurityUtil.getCurrentUserCode());
 
+        // 게시글 수정
         postAndImageService.teamPostUpdate(teamPostDTO, images);
 
 
@@ -68,6 +67,7 @@ public class TeamPostCommandController {
         // 로그인 중인 유저 코드 받아와 DTO에 삽입
         teamPostDTO.setUserCode(SecurityUtil.getCurrentUserCode());
 
+        // 게시글 삭제
         postAndImageService.teamPostDelete(teamPostDTO);
 
         return ResponseEntity.ok("팀 모집 게시글 삭제 성공");

--- a/back-end/with-the-developer/src/main/java/com/developer/teampost/command/controller/TeamPostCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/teampost/command/controller/TeamPostCommandController.java
@@ -4,15 +4,11 @@ package com.developer.teampost.command.controller;
 import com.developer.common.exception.CustomException;
 import com.developer.common.exception.ErrorCode;
 import com.developer.comu.module.PostAndImageService;
-import com.developer.image.command.service.ImageService;
 import com.developer.teampost.command.dto.TeamPostDeleteDTO;
 import com.developer.teampost.command.dto.TeamPostRegistDTO;
 import com.developer.teampost.command.dto.TeamPostUpdateDTO;
-import com.developer.teampost.command.service.TeamPostCommandService;
-import com.developer.user.command.dto.TokenSaveDTO;
 import com.developer.user.security.SecurityUtil;
 import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -25,26 +21,24 @@ import java.text.ParseException;
 
 
 @RestController
-@RequestMapping("/teamPost")
+@RequestMapping("/team")
 @Slf4j
 @RequiredArgsConstructor
 public class TeamPostCommandController {
 
-    private final TeamPostCommandService teamPostCommandService;
     private final PostAndImageService postAndImageService;
-    private final ImageService imageService;
 
     // 게시글 등록
     @PostMapping("/regist")
     public ResponseEntity<String> registTeamPost(
             @RequestPart TeamPostRegistDTO teamPostDTO,
-            @RequestPart MultipartFile[] images,
-            HttpServletRequest httpServletRequest) throws ParseException, IOException {
+            @RequestPart MultipartFile[] images
+    ) throws ParseException, IOException {
 
         // 로그인 중인 유저 코드 받아와 DTO에 삽입
-        teamPostDTO.setUserCode(getLoginUserCode(httpServletRequest));
+        teamPostDTO.setUserCode(SecurityUtil.getCurrentUserCode());
 
-        Long createdCode = postAndImageService.teamPostUpload(teamPostDTO, images);
+        Long createdCode = postAndImageService.teamPostRegist(teamPostDTO, images);
 
 
         // 추후 개발 시 생성된 teampost의 상세 페이지 진입을 위해 URI 작성하여 return
@@ -55,12 +49,11 @@ public class TeamPostCommandController {
     @PostMapping("/update")
     public ResponseEntity<String> updateTeamPost(
             @RequestPart TeamPostUpdateDTO teamPostDTO,
-            @RequestPart MultipartFile[] images,
-            HttpServletRequest httpServletRequest
+            @RequestPart MultipartFile[] images
     ) throws ParseException, IOException {
 
         // 로그인 중인 유저 코드 받아와 DTO에 삽입
-        teamPostDTO.setUserCode(getLoginUserCode(httpServletRequest));
+        teamPostDTO.setUserCode(SecurityUtil.getCurrentUserCode());
 
         postAndImageService.teamPostUpdate(teamPostDTO, images);
 
@@ -70,28 +63,14 @@ public class TeamPostCommandController {
 
     // 게시글 삭제
     @PostMapping("/delete")
-    public ResponseEntity<String> deleteTeamPost(@RequestBody TeamPostDeleteDTO teamPostDTO, HttpServletRequest httpServletRequest) throws ParseException {
+    public ResponseEntity<String> deleteTeamPost(@RequestBody TeamPostDeleteDTO teamPostDTO) throws ParseException {
 
         // 로그인 중인 유저 코드 받아와 DTO에 삽입
-        teamPostDTO.setUserCode(getLoginUserCode(httpServletRequest));
+        teamPostDTO.setUserCode(SecurityUtil.getCurrentUserCode());
 
         postAndImageService.teamPostDelete(teamPostDTO);
 
         return ResponseEntity.ok("팀 모집 게시글 삭제 성공");
-    }
-
-    // 현재 로그인 중인 유저 코드 반환 메소드
-    private Long getLoginUserCode(HttpServletRequest httpServletRequest){
-
-        Long loginUser = SecurityUtil.getCurrentUserCode();
-
-        // 로그인 중이 아니라면 예외발생
-        if(loginUser == null){
-            throw new CustomException(ErrorCode.NEED_LOGIN);
-        }
-
-        // 로그인 중인 유저 코드 리턴
-        return loginUser;
     }
 
 }

--- a/back-end/with-the-developer/src/main/java/com/developer/teampost/command/controller/TeamPostCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/teampost/command/controller/TeamPostCommandController.java
@@ -3,6 +3,7 @@ package com.developer.teampost.command.controller;
 
 import com.developer.common.exception.CustomException;
 import com.developer.common.exception.ErrorCode;
+import com.developer.comu.module.PostAndImageService;
 import com.developer.image.command.service.ImageService;
 import com.developer.teampost.command.dto.TeamPostDeleteDTO;
 import com.developer.teampost.command.dto.TeamPostRegistDTO;
@@ -30,6 +31,7 @@ import java.text.ParseException;
 public class TeamPostCommandController {
 
     private final TeamPostCommandService teamPostCommandService;
+    private final PostAndImageService postAndImageService;
     private final ImageService imageService;
 
     // 게시글 등록
@@ -42,13 +44,8 @@ public class TeamPostCommandController {
         // 로그인 중인 유저 코드 받아와 DTO에 삽입
         teamPostDTO.setUserCode(getLoginUserCode(httpServletRequest));
 
-        // 서비스 메소드 호출
-        Long createdCode = teamPostCommandService.registTeamPost(teamPostDTO);
+        Long createdCode = postAndImageService.teamPostUpload(teamPostDTO, images);
 
-        // 이미지도 같이 등록 할 경우 ImageService 호출
-        if(images!=null && images.length>0) {
-            imageService.upload(images, "teamPost", createdCode);
-        }
 
         // 추후 개발 시 생성된 teampost의 상세 페이지 진입을 위해 URI 작성하여 return
         return ResponseEntity.created(URI.create("teamPost/"+createdCode)).build();
@@ -65,13 +62,8 @@ public class TeamPostCommandController {
         // 로그인 중인 유저 코드 받아와 DTO에 삽입
         teamPostDTO.setUserCode(getLoginUserCode(httpServletRequest));
 
-        teamPostCommandService.updateTeamPost(teamPostDTO);
+        postAndImageService.teamPostUpdate(teamPostDTO, images);
 
-        if(images!=null && images.length>0) {
-            imageService.updateImage(images, "teamPost", teamPostDTO.getUserCode());
-        }else{
-            imageService.deleteImage("teampost", teamPostDTO.getUserCode());
-        }
 
         return ResponseEntity.ok("팀 모집 게시글 수정 성공");
     }
@@ -83,9 +75,7 @@ public class TeamPostCommandController {
         // 로그인 중인 유저 코드 받아와 DTO에 삽입
         teamPostDTO.setUserCode(getLoginUserCode(httpServletRequest));
 
-        imageService.deleteImage("teamPost", teamPostDTO.getTeamPostCode());
-
-        teamPostCommandService.deleteTeamPost(teamPostDTO);
+        postAndImageService.teamPostDelete(teamPostDTO);
 
         return ResponseEntity.ok("팀 모집 게시글 삭제 성공");
     }

--- a/back-end/with-the-developer/src/main/java/com/developer/user/command/controller/UserCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/user/command/controller/UserCommandController.java
@@ -1,6 +1,6 @@
 package com.developer.user.command.controller;
 
-import com.developer.common.SuccessCode;
+import com.developer.common.success.SuccessCode;
 import com.developer.common.jwt.TokenDTO;
 import com.developer.user.command.dto.*;
 import com.developer.user.command.service.EmailCommandService;
@@ -9,8 +9,6 @@ import com.developer.common.exception.CustomException;
 import com.developer.common.exception.ErrorCode;
 import com.developer.user.security.SecurityUtil;
 import jakarta.mail.MessagingException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;


### PR DESCRIPTION
- 게시글 업로드 시 이미지 업로드와 게시글 업로드가 하나의 트랜잭션으로 관리되도록 수정.
>> 게시글 업로드 서비스와 이미지 업로드 서비스에 동시 접근이 가능한 apllication 서비스 생성.

- 게시글 업로드 시 이미지가 존재하는지 확인하는 로직 수정
