### PR TITLE
[Feat/team] #91 팀 모집 게시글 직무 태그 추가 기능 구현

### DIFF
--- a/back-end/with-the-developer/src/main/java/com/developer/admin/command/controller/AdminCommandController.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/admin/command/controller/AdminCommandController.java
@@ -41,7 +41,7 @@ public class AdminCommandController {
     // ======== 직무태그 ========
     // 직무태그 등록하기
     @PostMapping("/job-tag/create")
-    public ResponseEntity<SuccessCode> createJobTag(@RequestParam String jobTagName) {
+    public ResponseEntity<SuccessCode> createJobTag(@RequestParam(name = "jobTagName") String jobTagName) {
         adminCommandService.createJobTag(jobTagName);
         return ResponseEntity.ok(SuccessCode.JOB_TAG_CREATE_OK);
     }

--- a/back-end/with-the-developer/src/main/java/com/developer/jobTag/entity/TeamTag.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/jobTag/entity/TeamTag.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 public class TeamTag {
 
     @EmbeddedId
-    TeamTagCompositeKey code;
+    private TeamTagCompositeKey code;
 
     @ManyToOne
     @MapsId("teamPostCode")

--- a/back-end/with-the-developer/src/main/java/com/developer/jobTag/entity/TeamTag.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/jobTag/entity/TeamTag.java
@@ -1,0 +1,36 @@
+package com.developer.jobTag.entity;
+
+
+import com.developer.team.post.command.entity.TeamPost;
+import jakarta.persistence.*;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "team_tag")
+@NoArgsConstructor
+public class TeamTag {
+
+    @EmbeddedId
+    TeamTagCompositeKey code;
+
+    @ManyToOne
+    @MapsId("teamPostCode")
+    @JoinColumn(name = "team_post_code")
+    private TeamPost teamPost;
+
+    @ManyToOne
+    @MapsId("jobTagCode")
+    @JoinColumn(name = "job_tag_code")
+    private JobTag jobTag;
+
+    public TeamTag(TeamPost teamPost, JobTag jobTag) {
+
+        this.teamPost = teamPost;
+        this.jobTag = jobTag;
+        this.code = new TeamTagCompositeKey(teamPost.getTeamPostCode(), jobTag.getJobTagCode());
+    }
+
+    public void updateTeamPost(TeamPost teamPost) {
+        this.teamPost = teamPost;
+    }
+}

--- a/back-end/with-the-developer/src/main/java/com/developer/jobTag/entity/TeamTag.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/jobTag/entity/TeamTag.java
@@ -1,6 +1,5 @@
 package com.developer.jobTag.entity;
 
-
 import com.developer.team.post.command.entity.TeamPost;
 import jakarta.persistence.*;
 import lombok.NoArgsConstructor;

--- a/back-end/with-the-developer/src/main/java/com/developer/jobTag/entity/TeamTagCompositeKey.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/jobTag/entity/TeamTagCompositeKey.java
@@ -1,0 +1,21 @@
+package com.developer.jobTag.entity;
+
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+
+// Team Tag 복합키
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class TeamTagCompositeKey implements Serializable {
+
+    private Long teamPostCode;
+
+    private Long jobTagCode;
+}

--- a/back-end/with-the-developer/src/main/java/com/developer/jobTag/repository/JobTagRepository.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/jobTag/repository/JobTagRepository.java
@@ -3,10 +3,12 @@ package com.developer.jobTag.repository;
 import com.developer.jobTag.entity.JobTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface JobTagRepository extends JpaRepository<JobTag, Long> {
 
     boolean existsByJobTagName(String jobTagName);
     Optional<JobTag> findByJobTagName(String jobTagName);
+    List<JobTag> findAllByJobTagNameIn(List<String> jobTagNames);
 }

--- a/back-end/with-the-developer/src/main/java/com/developer/jobTag/repository/TeamTagRepository.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/jobTag/repository/TeamTagRepository.java
@@ -1,0 +1,7 @@
+package com.developer.jobTag.repository;
+
+import com.developer.jobTag.entity.TeamTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamTagRepository extends JpaRepository<TeamTag, Long> {
+}

--- a/back-end/with-the-developer/src/main/java/com/developer/team/post/command/dto/TeamPostRegistDTO.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/team/post/command/dto/TeamPostRegistDTO.java
@@ -4,6 +4,8 @@ import com.developer.team.post.command.entity.TeamPost;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
+import java.util.List;
+
 // 팀 모집 등록에 필요한 데이터 DTO
 @Data
 public class TeamPostRegistDTO {
@@ -17,7 +19,11 @@ public class TeamPostRegistDTO {
     @NotNull(message = "팀 모집 마감일은 필수로 입력되어야 합니다.")
     private String teamPostDeadLine; // 팀 모집 게시글 마감일
 
+    private List<String> jobTagNames;
+
     private Long userCode; // 로그인 중인 유저 코드
+
+
 
     public TeamPost toEntity() {
         return TeamPost.builder()

--- a/back-end/with-the-developer/src/main/java/com/developer/team/post/command/dto/TeamPostRegistDTO.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/team/post/command/dto/TeamPostRegistDTO.java
@@ -23,8 +23,6 @@ public class TeamPostRegistDTO {
 
     private Long userCode; // 로그인 중인 유저 코드
 
-
-
     public TeamPost toEntity() {
         return TeamPost.builder()
                 .teamPostTitle(teamPostTitle)

--- a/back-end/with-the-developer/src/main/java/com/developer/team/post/command/dto/TeamPostUpdateDTO.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/team/post/command/dto/TeamPostUpdateDTO.java
@@ -3,6 +3,8 @@ package com.developer.team.post.command.dto;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
+import java.util.List;
+
 // 팀 모집 수정에 필요한 데이터 DTO
 @Data
 public class TeamPostUpdateDTO {
@@ -18,5 +20,9 @@ public class TeamPostUpdateDTO {
     @NotNull(message = "팀 모집 마감일은 필수로 입력되어야 합니다.")
     private String teamPostDeadLine; // 팀 모집 게시글 마감일
 
+    private List<String> jobTagNames;
+
     private Long userCode; // 현재 로그인 중인 유저 코드
+
+
 }

--- a/back-end/with-the-developer/src/main/java/com/developer/team/post/command/dto/TeamPostUpdateDTO.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/team/post/command/dto/TeamPostUpdateDTO.java
@@ -24,5 +24,4 @@ public class TeamPostUpdateDTO {
 
     private Long userCode; // 현재 로그인 중인 유저 코드
 
-
 }

--- a/back-end/with-the-developer/src/main/java/com/developer/team/post/command/entity/TeamPost.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/team/post/command/entity/TeamPost.java
@@ -1,6 +1,7 @@
 package com.developer.team.post.command.entity;
 
 import com.developer.common.util.BaseEntity;
+import com.developer.jobTag.entity.TeamTag;
 import com.developer.user.command.entity.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -9,7 +10,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 @Entity
 @Getter
@@ -35,15 +38,27 @@ public class TeamPost extends BaseEntity {
     @JoinColumn(name = "user_code")
     private User user;
 
+    @OneToMany(mappedBy = "teamPost")
+    private List<TeamTag> teamTags = new ArrayList<>();
+
+
     @Builder
-    public TeamPost(String teamPostTitle, String teamContent) {
+    public TeamPost(String teamPostTitle, String teamContent, List<TeamTag> teamTags) {
         this.teamPostTitle = teamPostTitle;
         this.teamContent = teamContent;
+        // teamTags 가 null 로 생성되는 것 방지
+        this.teamTags = teamTags != null ? teamTags : new ArrayList<>();
     }
 
     public void updateTeamPost(String teamPostTitle, String teamContent) {
         this.teamPostTitle = teamPostTitle;
         this.teamContent = teamContent;
+    }
+
+    public void addTeamTag(TeamTag teamTag) {
+
+        teamTags.add(teamTag);
+        teamTag.updateTeamPost(this);
     }
 
     public void updateDeadline(Date deadline) {

--- a/back-end/with-the-developer/src/main/java/com/developer/team/post/command/service/TeamPostCommandService.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/team/post/command/service/TeamPostCommandService.java
@@ -2,6 +2,10 @@ package com.developer.team.post.command.service;
 
 import com.developer.common.exception.CustomException;
 import com.developer.common.exception.ErrorCode;
+import com.developer.jobTag.entity.JobTag;
+import com.developer.jobTag.entity.TeamTag;
+import com.developer.jobTag.repository.JobTagRepository;
+import com.developer.jobTag.repository.TeamTagRepository;
 import com.developer.team.post.command.dto.TeamPostDeleteDTO;
 import com.developer.team.post.command.dto.TeamPostRegistDTO;
 import com.developer.team.post.command.dto.TeamPostUpdateDTO;
@@ -17,7 +21,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -26,6 +32,8 @@ public class TeamPostCommandService {
 
     private final TeamPostRepository teamPostRepository;
     private final UserRepository userRepository;
+    private final JobTagRepository jobTagRepository;
+    private final TeamTagRepository teamTagRepository;
 
     // 팀 모집 게시글 작성
     @Transactional
@@ -43,7 +51,20 @@ public class TeamPostCommandService {
         teamPost.updateDeadline(deadline);
         teamPost.updateUser(user);
 
+        for(String jobTagName : teamDTO.getJobTagNames()){
+
+            JobTag jobTag = jobTagRepository.findByJobTagName(jobTagName)
+                    .orElseThrow(() -> new CustomException(ErrorCode.NOT_FOUND_JOB_TAG));
+
+            TeamTag teamTag = new TeamTag(teamPost, jobTag);
+
+            teamPost.addTeamTag(teamTag);
+
+        }
+
+        // 팀 태그도 같이 저장
         teamPostRepository.save(teamPost);
+        teamTagRepository.saveAll(teamPost.getTeamTags());
 
         // 생성 된 teamPost 의 고유 번호 반환
         return teamPost.getTeamPostCode();
@@ -59,9 +80,40 @@ public class TeamPostCommandService {
 
         // 수정하려는 게시글이 현재 로그인 중인 유저의 게시글인지 확인
         if(teamDTO.getUserCode().equals(foundedTeamPost.getUser().getUserCode())) {
+
             // 맞다면 해당 팀 모집 게시판 엔터티 수정 후 저장
             foundedTeamPost.updateTeamPost(teamDTO.getTeamPostTitle(), teamDTO.getTeamContent());
             foundedTeamPost.updateDeadline(deadline);
+
+            /*
+            * 팀 태그 업데이트 방법.
+            * 1. 기존 팀 태그를 삭제한다.
+            * 2. 새로운 팀 태그를 등록한다.
+            * 3. 새로운 팀 태그를 teamPost 에 적용시킨다.
+            * */
+            // 기존 TeamTag 목록 가져오기
+            List<TeamTag> oldTeamTags = foundedTeamPost.getTeamTags();
+
+            // 새로운 JobTagName 목록을 기반으로 새 TeamTag 목록 생성
+            List<JobTag> newJobTags = jobTagRepository.findAllByJobTagNameIn(teamDTO.getJobTagNames());
+
+            List<TeamTag> newTeamTags = newJobTags.stream()
+                    .map(jobTag -> new TeamTag(foundedTeamPost, jobTag))
+                    .collect(Collectors.toList());
+
+            // 기존 TeamTag 삭제
+            teamTagRepository.deleteAll(oldTeamTags);
+
+            // 새 팀 태그 등록
+            teamTagRepository.saveAll(newTeamTags);
+
+            // TeamPost 의 TeamTag 목록 갱신
+            foundedTeamPost.getTeamTags().clear();
+            foundedTeamPost.getTeamTags().addAll(newTeamTags);
+
+            // TeamPost 저장
+            teamPostRepository.save(foundedTeamPost);
+
         }else{
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER);
         }
@@ -75,6 +127,8 @@ public class TeamPostCommandService {
 
         // 삭제하려는 게시글이 현재 로그인 중인 유저의 게시글인지 확인
         if(teamDTO.getUserCode().equals(foundedTeamPost.getUser().getUserCode())) {
+            // 팀 모집 게시글 삭제
+            teamTagRepository.deleteAll(foundedTeamPost.getTeamTags());
             teamPostRepository.delete(foundedTeamPost);
         }else{
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER);

--- a/back-end/with-the-developer/src/main/java/com/developer/team/post/command/service/TeamPostCommandService.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/team/post/command/service/TeamPostCommandService.java
@@ -62,8 +62,9 @@ public class TeamPostCommandService {
 
         }
 
-        // 팀 태그도 같이 저장
+        // 팀 게시물 저장
         teamPostRepository.save(teamPost);
+        // 팀 태그 저장
         teamTagRepository.saveAll(teamPost.getTeamTags());
 
         // 생성 된 teamPost 의 고유 번호 반환
@@ -127,8 +128,9 @@ public class TeamPostCommandService {
 
         // 삭제하려는 게시글이 현재 로그인 중인 유저의 게시글인지 확인
         if(teamDTO.getUserCode().equals(foundedTeamPost.getUser().getUserCode())) {
-            // 팀 모집 게시글 삭제
+            // 팀 모집 게시글 직무 태그 삭제
             teamTagRepository.deleteAll(foundedTeamPost.getTeamTags());
+            // 팀 모집 게시글 삭제
             teamPostRepository.delete(foundedTeamPost);
         }else{
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER);


### PR DESCRIPTION
팀 모집 게시글 직무 태그 추가 기능 구현
- jobTag, TeamPost와 연관관계 매핑
- 게시글 작성 시 TeamTag 함께 저장
- 게시글 수정 시 TeamTag 함께 수정 ( 기존 태그 삭제 후 새 태그 리스트 저장)
- 게시글 삭제 시 TeamTag 함께 삭제 ( DB상에서 완전 삭제)