### PR TITLE
[refactor/exceptions] #215 테스트하며 발생한 문제 처리

### DIFF
--- a/back-end/with-the-developer/src/main/java/com/developer/common/module/ReportReasonCategoryInitializer.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/common/module/ReportReasonCategoryInitializer.java
@@ -1,0 +1,36 @@
+package com.developer.common.module;
+
+import com.developer.report.command.entity.ReportReasonCategory;
+import com.developer.report.command.repository.ReportReasonCategoryRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReportReasonCategoryInitializer {
+
+    private final ReportReasonCategoryRepository reportReasonCategoryRepository;
+
+    @PostConstruct
+    public void init() {
+        if (reportReasonCategoryRepository.findAll().isEmpty()) {
+            List<ReportReasonCategory> reportReasonCategories = Arrays.asList(
+                    new ReportReasonCategory("부적절한 컨텐츠입니다."),
+                    new ReportReasonCategory("스팸 및 광고입니다."),
+                    new ReportReasonCategory("서비스 규칙 위반입니다."),
+                    new ReportReasonCategory("기타")
+            );
+
+            reportReasonCategoryRepository.saveAll(reportReasonCategories);
+
+            log.info("Report Reason Category 초기 저장 성공 {}", reportReasonCategories);
+        }
+    }
+}

--- a/back-end/with-the-developer/src/main/java/com/developer/team/post/command/dto/TeamPostRegistDTO.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/team/post/command/dto/TeamPostRegistDTO.java
@@ -1,6 +1,7 @@
 package com.developer.team.post.command.dto;
 
 import com.developer.team.post.command.entity.TeamPost;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ import java.util.List;
 public class TeamPostRegistDTO {
 
     @NotNull(message = "게시글 제목은 필수로 입력되어야 합니다.")
+    @NotBlank(message = "게시글 제목은 공백일 수 없습니다.")
     private String teamPostTitle; // 팀 모집 게시글 제목
 
     @NotNull(message = "게시글 본문은 필수로 입력되어야 합니다.")

--- a/back-end/with-the-developer/src/main/java/com/developer/team/post/command/service/TeamPostCommandService.java
+++ b/back-end/with-the-developer/src/main/java/com/developer/team/post/command/service/TeamPostCommandService.java
@@ -85,7 +85,11 @@ public class TeamPostCommandService {
             foundedTeamPost.updateDeadline(deadline);
 
             // 새로운 JobTag 목록으로 새 TeamTag 생성
+            List<String> jobTagNames = teamDTO.getJobTagNames();
             List<JobTag> newJobTags = jobTagRepository.findAllByJobTagNameIn(teamDTO.getJobTagNames());
+            if (newJobTags.size() != jobTagNames.size()) {
+                throw new CustomException(ErrorCode.NOT_FOUND_JOB_TAG);
+            }
             List<TeamTag> newTeamTags = newJobTags.stream()
                     .map(jobTag -> new TeamTag(foundedTeamPost, jobTag))
                     .collect(Collectors.toList());
@@ -99,7 +103,7 @@ public class TeamPostCommandService {
             // 게시글 저장
             teamPostRepository.save(foundedTeamPost);
 
-        }else{
+        } else{
             throw new CustomException(ErrorCode.UNAUTHORIZED_USER);
         }
     }


### PR DESCRIPTION
- 제목 입력 안해도 팀모집 게시글 올라가는 문제
- 팀모집 게시글 수정할 떄 없는 직무태그 넣어줘도 수정되고, TEAM_TAG 테이블에서 그 게시물의 직무태그 연관된 게 사라지는 문제
- 채용공고 수동 마감 APPROVE 된 것만 가능하게 바꾸기. 삭제도.. 이미 삭제된 거 예외처리
- 신고 카테고리에도 기본 데이터 넣어주기